### PR TITLE
Fixed WatchList Error

### DIFF
--- a/src/components/MovieCard.tsx
+++ b/src/components/MovieCard.tsx
@@ -20,7 +20,7 @@ const MovieCard: React.FC<MovieCardProps> = ({ movie }) => {
 const dispatch = useDispatch();
 
 
-const watchlist = useSelector((state: any) => state.movies.watchlist);
+const watchlist = useSelector((state: any) => state.movie.watchlist);
 const isInWatchlist = watchlist.some((m: Movie) => m.id === movie.id);
 
 

--- a/src/redux/MovieSlice.tsx
+++ b/src/redux/MovieSlice.tsx
@@ -54,7 +54,7 @@ export const fetchTrendingMovies = createAsyncThunk<Movie[]>(
 
 
 const movieSlice = createSlice({
-  name: 'movies',
+  name: 'movie',
   initialState,
   reducers: { 
   addToWatchlist: (state, action: PayloadAction<Movie>) => { 


### PR DESCRIPTION
Changed Reducer name from movies to movie since in most of the pages you have accessed as movie including store and in MovieCard I Have update the state call as state.movie instead of state.movies